### PR TITLE
fix formatter detection and simplify main module

### DIFF
--- a/flake_fmt/__main__.py
+++ b/flake_fmt/__main__.py
@@ -9,57 +9,32 @@ import sys
 from pathlib import Path
 from subprocess import PIPE
 
-# Create module-specific logger
 logger = logging.getLogger(__name__)
 
 
 def find_flake_root(start_path: Path | None = None) -> Path | None:
-    """Find the nearest flake.nix by searching up the directory tree.
+    """Find the nearest flake.nix walking up, stopping at git boundaries."""
+    start = (start_path or Path.cwd()).resolve()
+    logger.debug("Searching for flake.nix starting from: %s", start)
 
-    Stops at git repository boundaries (.git directory).
-    """
-    if start_path is None:
-        start_path = Path.cwd()
-    current = start_path.resolve()
-    logger.debug("Searching for flake.nix starting from: %s", current)
-
-    while current != current.parent:
-        flake_path = current / "flake.nix"
-        if flake_path.exists():
+    for current in [start, *start.parents]:
+        if (current / "flake.nix").exists():
             logger.debug("Found flake.nix at: %s", current)
             return current
-
-        # Stop at git repository boundaries
         if (current / ".git").exists():
             logger.debug("Stopped at git boundary: %s", current)
             return None
-
-        current = current.parent
-
-    # Check root directory
-    flake_path = current / "flake.nix"
-    if flake_path.exists():
-        logger.debug("Found flake.nix at root: %s", current)
-        return current
 
     logger.debug("No flake.nix found")
     return None
 
 
 def parse_arguments(args: list[str]) -> tuple[list[str], list[str]]:
-    """Parse command line arguments into nix args and formatter args.
-
-    Everything before '--' goes to nix, everything after goes to the formatter.
-    """
-    if "--" in args:
-        split_index = args.index("--")
-        nix_args = args[:split_index]
-        formatter_args = args[split_index + 1 :]
-    else:
-        nix_args = args
-        formatter_args = []
-
-    return nix_args, formatter_args
+    """Split args on '--': before goes to nix, after goes to the formatter."""
+    if "--" not in args:
+        return args, []
+    i = args.index("--")
+    return args[:i], args[i + 1 :]
 
 
 def run_nix(
@@ -70,92 +45,47 @@ def run_nix(
     stderr: int | None = None,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a nix command with proper error handling."""
+    """Run a nix command with experimental features enabled."""
     cmd = ["nix", "--extra-experimental-features", "flakes nix-command", *args]
-
     return subprocess.run(cmd, check=check, stdout=stdout, stderr=stderr, text=True, cwd=cwd, shell=False)
 
 
-def get_current_system() -> str:
-    """Get the current system identifier."""
-    return run_nix(["config", "show", "system"], stdout=PIPE).stdout.strip()
+def get_cache_path(toplevel: Path) -> Path:
+    """Cache file path for this flake (one symlink per flake root)."""
+    digest = hashlib.sha256(str(toplevel).encode()).hexdigest()
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+    path = cache_home / "flake-fmt" / digest
+    logger.debug("Formatter cache path: %s (from %s)", path, toplevel)
+    return path
 
 
-def get_cache_path(toplevel: Path) -> tuple[Path, Path]:
-    """Get cache directory and formatter cache path."""
-    escaped_toplevel = hashlib.sha256(str(toplevel).encode()).hexdigest()
-    cache_home = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
-    cache_dir = Path(cache_home) / "flake-fmt"
-    fmt_cache_path = cache_dir / escaped_toplevel
-    logger.debug("Cache directory: %s", cache_dir)
-    logger.debug("Formatter cache path: %s", fmt_cache_path)
-    logger.debug("Cache path hash (from %s): %s", toplevel, escaped_toplevel)
-    return cache_dir, fmt_cache_path
-
-
-def check_cache_validity(fmt_cache_path: Path, toplevel: Path) -> tuple[bool, list[str]]:
-    """Check if cache needs update and return build args."""
-    needs_update = False
-    build_args = []
-
+def cache_is_stale(fmt_cache_path: Path, toplevel: Path) -> bool:
+    """Return True if the cache symlink is missing, forced, or older than flake inputs."""
+    if os.environ.get("NO_CACHE"):
+        logger.debug("NO_CACHE set, forcing rebuild")
+        return True
     if not fmt_cache_path.exists():
-        logger.debug("Cache does not exist at %s, needs rebuild", fmt_cache_path)
-        needs_update = True
-    elif os.environ.get("NO_CACHE"):
-        logger.debug("NO_CACHE environment variable set, forcing rebuild")
-        needs_update = True
-    else:
-        build_args.extend(["-o", str(fmt_cache_path)])
-        reference_time = fmt_cache_path.lstat().st_mtime
-        logger.debug("Cache exists, last modified: %s", reference_time)
+        logger.debug("Cache missing at %s", fmt_cache_path)
+        return True
 
-        # Check if flake.nix or flake.lock are newer
-        for file in ["flake.nix", "flake.lock"]:
-            file_path = toplevel / file
-            if file_path.exists():
-                file_mtime = file_path.stat().st_mtime
-                logger.debug("%s last modified: %s", file, file_mtime)
-                if file_mtime > reference_time:
-                    logger.debug("%s is newer than cache (%s > %s), needs rebuild", file, file_mtime, reference_time)
-                    needs_update = True
-                    break
-            else:
-                logger.debug("%s does not exist", file)
-
-    logger.debug("Cache validity check result: needs_update=%s", needs_update)
-    return needs_update, build_args
+    ref_mtime = fmt_cache_path.lstat().st_mtime
+    for name in ("flake.nix", "flake.lock"):
+        f = toplevel / name
+        if f.exists() and f.stat().st_mtime > ref_mtime:
+            logger.debug("%s newer than cache, rebuild needed", name)
+            return True
+    logger.debug("Cache up to date")
+    return False
 
 
 def build_formatter(
     toplevel: Path,
-    current_system: str,
     fmt_cache_path: Path,
-    build_args: list[str],
     nix_args: list[str],
 ) -> Path:
-    """Build the formatter if needed."""
+    """Build .#formatter.<system> into fmt_cache_path. Returns store path."""
+    current_system = run_nix(["config", "show", "system"], stdout=PIPE).stdout.strip()
     logger.debug("Building formatter for system: %s", current_system)
-
-    # Check if formatter exists for current system
-    has_formatter_check = f"(val: val ? {current_system})"
-    try:
-        logger.debug("Checking if formatter exists for %s", current_system)
-        result = run_nix(
-            ["eval", ".#formatter", "--apply", has_formatter_check, *nix_args], cwd=toplevel, stdout=PIPE, stderr=PIPE
-        )
-        if result.stdout.strip() != "true":
-            logger.debug("No formatter defined for current system")
-            print("Warning: No formatter defined", file=sys.stderr)
-            sys.exit(0)
-    except subprocess.CalledProcessError as e:
-        # If the formatter attribute doesn't exist at all, nix will error
-        if e.stderr and "does not provide attribute" in e.stderr:
-            logger.debug("Formatter attribute does not exist")
-            print("Warning: No formatter defined", file=sys.stderr)
-            sys.exit(0)
-        raise
-
-    # Build formatter
     build_cmd = [
         "build",
         "--print-out-paths",
@@ -164,95 +94,80 @@ def build_formatter(
         "--builders",
         "",
         "--keep-failed",
-        *build_args,
         *nix_args,
         f".#formatter.{current_system}",
     ]
-    logger.debug("Running build command: nix %s", " ".join(build_cmd))
-    fmt_path = run_nix(build_cmd, cwd=toplevel, stdout=PIPE)
-    result_path = Path(fmt_path.stdout.strip())
-    logger.debug("Formatter built successfully at: %s", result_path)
-    return result_path
+    logger.debug("Running: nix %s", " ".join(build_cmd))
+    try:
+        result = run_nix(build_cmd, cwd=toplevel, stdout=PIPE, stderr=PIPE)
+    except subprocess.CalledProcessError as e:
+        if e.stderr:
+            sys.stderr.write(e.stderr)
+        if e.stderr and "does not provide attribute" in e.stderr:
+            print("Warning: No formatter defined", file=sys.stderr)
+            sys.exit(1)
+        sys.exit(e.returncode)
+    out = Path(result.stdout.strip())
+    logger.debug("Formatter built at: %s", out)
+    return out
+
+
+def find_executable(fmt_cache_path: Path) -> Path | None:
+    """Pick formatter executable: prefer treefmt, else first executable in bin/ (sorted)."""
+    bin_dir = fmt_cache_path / "bin"
+    if not bin_dir.is_dir():
+        return None
+    treefmt = bin_dir / "treefmt"
+    if treefmt.exists() and os.access(treefmt, os.X_OK):
+        return treefmt
+    for f in sorted(bin_dir.iterdir()):
+        if f.is_file() and os.access(f, os.X_OK):
+            return f
+    return None
 
 
 def execute_formatter(fmt_cache_path: Path, formatter_args: list[str], toplevel: Path) -> None:
-    """Execute the formatter."""
-    # Check for treefmt first (it has multiple outputs)
-    treefmt_path = fmt_cache_path / "bin" / "treefmt"
-    if treefmt_path.exists() and os.access(treefmt_path, os.X_OK):
-        logger.debug("Executing treefmt: %s with args: %s", treefmt_path, formatter_args)
-        result = subprocess.run([str(treefmt_path), *formatter_args], check=False, cwd=toplevel, shell=False)
-        sys.exit(result.returncode)
-
-    # Find any executable in bin directory
-    bin_dir = fmt_cache_path / "bin"
-    if bin_dir.exists():
-        logger.debug("Checking for executables in: %s", bin_dir)
-        for file_path in bin_dir.iterdir():
-            if file_path.is_file() and os.access(file_path, os.X_OK):
-                logger.debug("Executing formatter: %s with args: %s", file_path, formatter_args)
-                result = subprocess.run([str(file_path), *formatter_args], check=False, cwd=toplevel, shell=False)
-                sys.exit(result.returncode)
-
-    # If no executable found, the formatter itself might be executable
-    if os.access(fmt_cache_path, os.X_OK):
-        logger.debug("Executing formatter directly: %s with args: %s", fmt_cache_path, formatter_args)
-        result = subprocess.run([str(fmt_cache_path), *formatter_args], check=False, cwd=toplevel, shell=False)
-        sys.exit(result.returncode)
-
-    logger.error("No executable formatter found at %s", fmt_cache_path)
-    sys.exit(1)
+    """Replace current process with the formatter."""
+    exe = find_executable(fmt_cache_path)
+    if exe is None:
+        logger.error("No executable formatter found at %s", fmt_cache_path)
+        sys.exit(1)
+    logger.debug("Exec %s with args: %s", exe, formatter_args)
+    os.chdir(toplevel)
+    os.execv(str(exe), [str(exe), *formatter_args])  # noqa: S606
 
 
 def main(args: list[str] | None = None) -> None:
     """Run the flake formatter with caching."""
-    # Set up logging
-    log_level = os.environ.get("FLAKE_FMT_DEBUG", "").lower()
-    if log_level in ["1", "true", "yes", "on"]:
+    if os.environ.get("FLAKE_FMT_DEBUG", "").lower() in {"1", "true", "yes", "on"}:
         logging.basicConfig(level=logging.DEBUG, format="[%(levelname)s] %(message)s")
-        logger.debug("Debug logging enabled via FLAKE_FMT_DEBUG environment variable")
+        logger.debug("Debug logging enabled via FLAKE_FMT_DEBUG")
 
     try:
-        # Parse arguments
-        if args is None:
-            args = sys.argv[1:]
-        nix_args, formatter_args = parse_arguments(args)
-        logger.debug("Nix args: %s", nix_args)
-        logger.debug("Formatter args: %s", formatter_args)
+        nix_args, formatter_args = parse_arguments(sys.argv[1:] if args is None else args)
+        logger.debug("Nix args: %s | Formatter args: %s", nix_args, formatter_args)
 
-        # Find flake root
         toplevel = find_flake_root()
         if toplevel is None:
             print("No flake.nix found", file=sys.stderr)
             sys.exit(1)
         logger.debug("Flake root: %s", toplevel)
 
-        # Get current system
-        current_system = get_current_system()
-        logger.debug("Current system: %s", current_system)
+        fmt_cache_path = get_cache_path(toplevel)
 
-        # Set up cache
-        cache_dir, fmt_cache_path = get_cache_path(toplevel)
-
-        # Check cache validity
-        needs_update, build_args = check_cache_validity(fmt_cache_path, toplevel)
-
-        if needs_update:
-            logger.debug("Triggering formatter rebuild")
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            fmt_cache_path = build_formatter(toplevel, current_system, fmt_cache_path, build_args, nix_args)
+        if cache_is_stale(fmt_cache_path, toplevel):
+            fmt_cache_path.parent.mkdir(parents=True, exist_ok=True)
+            fmt_cache_path = build_formatter(toplevel, fmt_cache_path, nix_args)
         else:
             logger.debug("Using cached formatter")
 
-        # Execute formatter
-        logger.debug("Executing formatter from: %s", fmt_cache_path)
         execute_formatter(fmt_cache_path, formatter_args, toplevel)
     except KeyboardInterrupt:
-        # Exit cleanly on Ctrl-C
         sys.exit(130)
     except subprocess.CalledProcessError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(e.returncode)
+        msg = e.stderr or str(e)
+        print(f"Error: {msg}", file=sys.stderr)
+        sys.exit(e.returncode or 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

The pre-build existence check evaluated '.#formatter' and tested whether
the result had the current system as an attribute. Nix's CLI shorthand
auto-resolves '.#formatter' to the per-system derivation directly, so
'val ? aarch64-darwin' is always false and flakes correctly exposing
formatter.<system> were reported as missing one. Drop the pre-check
and detect a genuinely missing attribute from 'nix build' stderr.

Also fix a duplicate '-o'/'--out-link' on stale-cache rebuilds, honour
NO_CACHE when the cache is missing, sort bin/ entries (prefer treefmt)
so executable selection is deterministic, surface nix stderr on build
failure instead of hiding it behind repr(e), and exit non-zero when
no formatter is defined so CI notices.

Replace subprocess+sys.exit with os.execv in execute_formatter, inline
get_current_system so it only runs on rebuild, and collapse
find_flake_root to a single parents walk.


